### PR TITLE
feature: Integrated text editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.35.0",
+        "@codemirror/lang-javascript": "^6.2.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@uiw/codemirror-theme-tokyo-night": "^4.22.1",
         "@uiw/react-codemirror": "^4.22.1",
         "bcrypt": "^5.1.0",
         "dotenv": "^16.0.3",
@@ -3337,6 +3339,20 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
+      "integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.1.tgz",
@@ -4629,6 +4645,16 @@
       "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.4.16",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.16.tgz",
+      "integrity": "sha512-84UXR3N7s11MPQHWgMnjb9571fr19MmXnr5zTv2XX0gHXXUvW3uPJ8GCjKrfTXmSdfktjRK0ayKklw+A13rk4g==",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -8995,6 +9021,35 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/lint": ">=6.0.0",
         "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-tokyo-night": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.22.1.tgz",
+      "integrity": "sha512-bF3yvrsvlIi1XBXdDkOC9JXtYvpbrSigJUwjSDl3qB2vdKAF3Cuw6/wVzAma3aG5Smy3FMjH4KMww9TStpNcUQ==",
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.22.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.22.1.tgz",
+      "integrity": "sha512-5TeB8wCc0aNd3YEhzOvgekpAFQfEm4fCTUcGmEIQqaRNgKAM83HYNpE1JF2j7x2oDFugdiO0yJynS6bo1zVOuw==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@uiw/react-codemirror": "^4.22.1",
         "bcrypt": "^5.1.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -3308,6 +3309,93 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.0.tgz",
+      "integrity": "sha512-P/LeCTtZHRTCU4xQsa89vSKWecYv1ZqwzOd5topheGRf+qtacFgBeIMQi3eL8Kt/BUNvxUWkx+5qP2jlGoARrg==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.5.0.tgz",
+      "integrity": "sha512-rK+sj4fCAN/QfcY9BEzYMgp4wwL/q5aj/VfNSoH1RWPF9XS/dUwBkvlL3hpWgEjOqlpdN1uLC9UkjJ4tmyjJYg==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.1.tgz",
+      "integrity": "sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.7.1.tgz",
+      "integrity": "sha512-rELba6QJD20/bNXWP/cKTGLrwVEcpa2ViwULCV03ONcY1Je85++7sczVRUlnE4TJMjatx3IJTz6HX4NXi+moXw==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.6.tgz",
+      "integrity": "sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
+      "integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.26.3.tgz",
+      "integrity": "sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==",
+      "dependencies": {
+        "@codemirror/state": "^6.4.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -4529,6 +4617,27 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
+      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
+      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
+      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
@@ -8864,6 +8973,57 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.22.1.tgz",
+      "integrity": "sha512-Iz8eFaZBNrwjaAADszOxOv2byDMn4rqob/luuSPAzJjTrSn5KawRXcoNLoWGPGNO6Mils6bIly/g2LaU34otNw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.22.1.tgz",
+      "integrity": "sha512-yrq9FdGZ6E4Rh+7W0xyirSEeESGyG/k54/DfFqSk40fqel/3x/3fqjIImEZUYPxxgFPmZ3RtP+O0Em46nwRvgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.22.1",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -10387,6 +10547,20 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -10617,6 +10791,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -21088,6 +21267,11 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -21930,6 +22114,11 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "dependencies": {
     "@adobe/react-spectrum": "^3.35.0",
+    "@codemirror/lang-javascript": "^6.2.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@uiw/codemirror-theme-tokyo-night": "^4.22.1",
     "@uiw/react-codemirror": "^4.22.1",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@uiw/react-codemirror": "^4.22.1",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -1,0 +1,22 @@
+.editor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.cm-theme {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+}
+
+.cm-theme .cm-editor {
+  height: 100%;
+}

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
+import { javascript } from '@codemirror/lang-javascript';
+import { tokyoNight } from '@uiw/codemirror-theme-tokyo-night';
 
 export default function Editor() {
   const [text, setText] = useState('');
@@ -8,6 +10,7 @@ export default function Editor() {
       <CodeMirror
         value={text}
         onChange={(value) => setText(value)}
+        theme={tokyoNight}
         height="300px"
         style={{ textAlign: 'left' }}
         options={{
@@ -15,6 +18,7 @@ export default function Editor() {
           tabSize: 2,
           indentWithTabs: true,
         }}
+        extensions={[javascript({ jsx: true })]}
       />
     </>
   );

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -2,17 +2,17 @@ import { useState } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
 import { tokyoNight } from '@uiw/codemirror-theme-tokyo-night';
+import './Editor.css';
 
 export default function Editor() {
   const [text, setText] = useState('');
   return (
-    <>
+    <div className='editor'>
       <CodeMirror
         value={text}
         onChange={(value) => setText(value)}
         theme={tokyoNight}
-        height="300px"
-        style={{ textAlign: 'left' }}
+        style={{ textAlign: 'left', overflow: 'auto' }}
         options={{
           lineNumbers: true,
           tabSize: 2,
@@ -20,6 +20,6 @@ export default function Editor() {
         }}
         extensions={[javascript({ jsx: true })]}
       />
-    </>
+    </div>
   );
 }

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -4,13 +4,19 @@ import { javascript } from '@codemirror/lang-javascript';
 import { tokyoNight } from '@uiw/codemirror-theme-tokyo-night';
 import './Editor.css';
 
-export default function Editor() {
+export default function Editor({ setContent }) {
   const [text, setText] = useState('');
+
+  const handleOnChange = (textValue) => {
+    setText(textValue);
+    setContent(textValue);
+  };
+
   return (
     <div className='editor'>
       <CodeMirror
         value={text}
-        onChange={(value) => setText(value)}
+        onChange={(value) => handleOnChange(value)}
         theme={tokyoNight}
         style={{ textAlign: 'left', overflow: 'auto' }}
         options={{

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -4,7 +4,7 @@ import { javascript } from '@codemirror/lang-javascript';
 import { tokyoNight } from '@uiw/codemirror-theme-tokyo-night';
 import './Editor.css';
 
-export default function Editor({ setContent }) {
+export default function Editor({ setContent, isEditorActive }) {
   const [text, setText] = useState('');
 
   const handleOnChange = (textValue) => {
@@ -13,7 +13,7 @@ export default function Editor({ setContent }) {
   };
 
   return (
-    <div className='editor'>
+    <div className='editor' style={{ visibility: `${isEditorActive ? 'visible' : 'hidden'}` }}>
       <CodeMirror
         value={text}
         onChange={(value) => handleOnChange(value)}
@@ -25,6 +25,7 @@ export default function Editor({ setContent }) {
           indentWithTabs: true,
         }}
         extensions={[javascript({ jsx: true })]}
+        autoFocus={isEditorActive}
       />
     </div>
   );

--- a/src/components/Editor/Editor.jsx
+++ b/src/components/Editor/Editor.jsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import CodeMirror from '@uiw/react-codemirror';
+
+export default function Editor() {
+  const [text, setText] = useState('');
+  return (
+    <>
+      <CodeMirror
+        value={text}
+        onChange={(value) => setText(value)}
+        height="300px"
+        style={{ textAlign: 'left' }}
+        options={{
+          lineNumbers: true,
+          tabSize: 2,
+          indentWithTabs: true,
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/NewFileForm/NewFileForm.css
+++ b/src/components/NewFileForm/NewFileForm.css
@@ -1,0 +1,24 @@
+.new-file-form form {
+  display: block;
+}
+
+.new-file-form .textarea-container {
+  position: relative;
+}
+
+.new-file-form input {
+  display: block;
+  margin-bottom: 1.25rem;
+}
+
+.new-file-form textarea {
+  width: 100%;
+  height: 300px;
+  padding: 10px;
+  font-family: monospace;
+  color: lightgray;
+  background-color: #1a1b26;
+  white-space: pre-wrap;
+  overflow: auto;
+  resize: none;
+}

--- a/src/components/NewFileForm/NewFileForm.jsx
+++ b/src/components/NewFileForm/NewFileForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Editor from '../Editor/Editor';
 
 export default function NewFileForm({ addFile, user }) {
   const [content, setContent] = useState('');
@@ -32,6 +33,7 @@ export default function NewFileForm({ addFile, user }) {
         />
         <button type="submit">SAVE FILE</button>
       </form>
+      <Editor />
     </div>
   );
 }

--- a/src/components/NewFileForm/NewFileForm.jsx
+++ b/src/components/NewFileForm/NewFileForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './NewFileForm.css';
+import Editor from '../Editor/Editor';
 
 export default function NewFileForm({ addFile, user }) {
   const [content, setContent] = useState('');
@@ -27,12 +28,11 @@ export default function NewFileForm({ addFile, user }) {
           <div className="textarea-container">
             <textarea
               value={content}
-              onChange={(evt) => setContent(evt.target.value)}
               placeholder="Content..."
               required
               pattern=".{4,}"
-              readOnly
             />
+            <Editor setContent={setContent} />
           </div>
           <button type="submit">SAVE FILE</button>
         </form>

--- a/src/components/NewFileForm/NewFileForm.jsx
+++ b/src/components/NewFileForm/NewFileForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import Editor from '../Editor/Editor';
+import './NewFileForm.css';
 
 export default function NewFileForm({ addFile, user }) {
   const [content, setContent] = useState('');
@@ -16,24 +16,26 @@ export default function NewFileForm({ addFile, user }) {
   return (
     <div className="new-file-form">
       <h2>New File</h2>
-      <form onSubmit={handleAddFile}>
-        <input
-          value={filename}
-          onChange={(evt) => setFilename(evt.target.value)}
-          placeholder="Filename"
-          required
-          pattern=".{4,}"
-        />
-        <textarea
-          value={content}
-          onChange={(evt) => setContent(evt.target.value)}
-          placeholder="Content..."
-          required
-          pattern=".{4,}"
-        />
-        <button type="submit">SAVE FILE</button>
-      </form>
-      <Editor />
+        <form onSubmit={handleAddFile}>
+          <input
+            value={filename}
+            onChange={(evt) => setFilename(evt.target.value)}
+            placeholder="Filename"
+            required
+            pattern=".{4,}"
+          />
+          <div className="textarea-container">
+            <textarea
+              value={content}
+              onChange={(evt) => setContent(evt.target.value)}
+              placeholder="Content..."
+              required
+              pattern=".{4,}"
+              readOnly
+            />
+          </div>
+          <button type="submit">SAVE FILE</button>
+        </form>
     </div>
   );
 }

--- a/src/components/NewFileForm/NewFileForm.jsx
+++ b/src/components/NewFileForm/NewFileForm.jsx
@@ -1,10 +1,26 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './NewFileForm.css';
 import Editor from '../Editor/Editor';
 
 export default function NewFileForm({ addFile, user }) {
   const [content, setContent] = useState('');
   const [filename, setFilename] = useState('');
+  const [isEditorActive, setIsEditorActive] = useState(false);
+  const textareaContainerRef = useRef(null);
+
+  useEffect(() => {
+    const onBodyClick = (evt) => {
+      const textareaContainer = textareaContainerRef.current;
+      if (textareaContainer.contains(evt.target) && isEditorActive === false) {
+        return;
+      }
+      setIsEditorActive(false);
+    };
+    document.body.addEventListener('click', onBodyClick);
+    return () => {
+      document.body.removeEventListener('click', onBodyClick);
+    };
+  }, []);
 
   async function handleAddFile(evt) {
     evt.preventDefault();
@@ -25,14 +41,16 @@ export default function NewFileForm({ addFile, user }) {
             required
             pattern=".{4,}"
           />
-          <div className="textarea-container">
+          <div className="textarea-container" ref={textareaContainerRef}>
             <textarea
               value={content}
+              onChange={(evt) => evt.preventDefault()}
+              onClick={() => setIsEditorActive(true)}
               placeholder="Content..."
               required
               pattern=".{4,}"
             />
-            <Editor setContent={setContent} />
+            <Editor setContent={setContent} isEditorActive={isEditorActive} />
           </div>
           <button type="submit">SAVE FILE</button>
         </form>


### PR DESCRIPTION
I integrated a code editor in the NewFileForm component, using the @uiw/react-codemirror package. You can now toggle between a code editor view and "read-only" view.

**Details**
- To make the view toggling work, I made a few edits to NewFileForm, including some style additions and a .textarea-container div to wrap textarea in the form. 
- I also made use of useRef, useEffect, and an additional piece of state, isEditorActive.

**Editor component notes** 
- The Editor component only supports JS language for now, but we can add others in the future.
- There are several themes available to choose from other than the one that's currently set (tokyoNight).